### PR TITLE
For #6: Fix 'svrepstat' output of `svyquantile()` 

### DIFF
--- a/R/confint.R
+++ b/R/confint.R
@@ -15,7 +15,16 @@ confint.svyratio<-confint.svystat
 tconfint<-function (object, parm, level = 0.95, df=Inf) 
 {
     cf <- coef(object)
-    pnames <- names(cf)
+    if (is.matrix(cf)) {
+      pnames <- sapply(X = colnames(cf),
+                       FUN = function(x) paste(rownames(cf), x, sep = "_"),
+                       simplify = TRUE)
+      pnames <- as.vector(pnames)
+      cf <- as.vector(cf)
+      names(cf) <- pnames
+    } else {
+      pnames <- names(cf)
+    }
     if (missing(parm)) 
         parm <- pnames
     else if (is.numeric(parm)) 
@@ -24,9 +33,13 @@ tconfint<-function (object, parm, level = 0.95, df=Inf)
     a <- c(a, 1 - a)
     pct <- format.perc(a, 3)
     fac <- qt(a, df=df)
-    ci <- array(NA, dim = c(length(parm), 2L), dimnames = list(parm, 
-        pct))
-    ses <- unlist(SE(object))[parm %in% pnames]
-    ci[] <- cf[parm] + ses %o% fac
-    ci
+    ci <- array(NA, dim = c(length(parm), 2L), dimnames = list(parm, pct))
+    if (!is.matrix(cf)) {
+      ses <- unlist(SE(object))[parm %in% pnames]
+    } else {
+      ses <- as.vector(SE(object))[parm %in% pnames]
+    }
+      ci[] <- cf[parm] + ses %o% fac
+      ci
+
 }

--- a/R/newsvyquantile.R
+++ b/R/newsvyquantile.R
@@ -123,14 +123,22 @@ svyquantile.svyrep.design <- function (x, design, quantiles, alpha = 0.05,
                                            )
                       }
                       )
-              ests<-sapply(rvals, function(v) sapply(v, function(qi) qi$qhat))
+              ests<-sapply(rvals, function(v) sapply(v, function(qi) qi$quantile))
+              ests <- matrix(ests, nrow = length(quantiles), ncol = length(rvals),
+                             dimnames=list(paste("q",round(quantiles,2),sep=""), names(x)))
               attr(ests, "scale") <- design$scale
               attr(ests, "rscales") <- design$rscales
               attr(ests, "mse") <- design$mse
-              reps<-sapply(rvals, function(v) t(sapply(v, function(qi) qi$replicates)))
-              rval<-list(quantile=ests,replicates=reps)
-              
-              attr(rval,"var")<-svrVar(reps, design$scale, design$rscales, mse=design$mse, coef=ests)
+              reps<-sapply(rvals, function(v) sapply(v, function(qi) qi$replicates))
+              reps <- matrix(reps, ncol = nrow(ests) * ncol(ests))
+              colnames(reps) <- as.vector(outer(names(x), paste("q",round(quantiles,2),sep=""), paste))
+          
+              rval <- ests
+              attr(rval,"statistic") <- 'quantiles'
+              vv <- svrVar(reps, design$scale, design$rscales, mse=design$mse, coef=ests)
+              attr(rval,"var") <- matrix(diag(vv), nrow = nrow(ests), ncol = ncol(ests),
+                                         dimnames=list(paste("q",round(quantiles,2),sep=""), names(x)))
+              rval<-list(quantile=rval,replicates=reps)
               class(rval)<-"svrepstat"
               return(rval)
     } else {


### PR DESCRIPTION
This pull request fixes the issue of #6. The output now has the same structure as the output from `oldsvyquantile()`.

``` r
library(survey)

# Create an example replicate survey design object ----
  data('api', package = 'survey')
  
  boot_design <- svydesign(
    ids = ~ 1, strata = ~ stype,
    weights = ~ pw,
    data = apistrat,
  ) |> as.svrepdesign(type = "boot")
  
# Attempt to estimate variance of quantile using direct replication ----
  new <- svyquantile(
    x = ~ api00 + api99,
    quantiles = c(0.25, 0.75),
    design = boot_design,
    interval.type = "quantile",
    return.replicates = TRUE
  )
  
  print(new)
#> Statistic:
#>       api00 api99
#> q0.25   565   526
#> q0.75   756   728
#> SE:
#>          api00    api99
#> q0.25 17.46244 14.95897
#> q0.75 13.00191 19.17167
  
  old <- oldsvyquantile(
    x = ~ api00 + api99,
    quantiles = c(0.25, 0.75),
    design = boot_design,
    interval.type = "quantile",
    return.replicates = TRUE
  )
  
  print(old)
#> Statistic:
#>          api00    api99
#> q0.25 562.2056 525.4800
#> q0.75 755.1226 726.7813
#> SE:
#>          api00    api99
#> q0.25 17.43040 14.47248
#> q0.75 12.85875 18.69856
```

<sup>Created on 2023-02-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


The second of the two commits in the pull request fixes a separate, lingering bug with the confidence intervals for both `svyquantile()` and `oldsvyquantile()`., which is discussed separately here: https://github.com/bschneidr/survey/issues/1

Currently, this is what we see when using `confint()`.
``` r
  confint(new)
#>      2.5 % 97.5 %
  confint(old)
#>      2.5 % 97.5 %
```

The second commit (f6bf0e9e3022f04bb4015b408eac1ab7b0f1b3d4) fixes this, so that we see the following: 

``` r
confint(new)
#>                2.5 %   97.5 %
#> q0.25_api00 534.7371 595.2629
#> q0.75_api00 733.7651 778.2349
#> q0.25_api99 505.5785 546.4215
#> q0.75_api99 697.0280 758.9720

confint(old)
#>                2.5 %   97.5 %
#> q0.25_api00 532.5228 591.8884
#> q0.75_api00 733.4364 776.8087
#> q0.25_api99 505.2796 545.6804
#> q0.75_api99 695.1486 758.4140
```








<sup>Created on 2023-02-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
