### PR TITLE
Fix raking issue by only computing marginal tables and not the full n-way table

### DIFF
--- a/R/surveyrep.R
+++ b/R/surveyrep.R
@@ -1980,11 +1980,10 @@ rake<-function(design, sample.margins, population.margins,
                    )
     
 
-    allterms<-unlist(lapply(sample.margins,all.vars))
-    ff<-formula(paste("~", paste(allterms,collapse="+"),sep=""))
-    oldtable<-svytable(ff, design)
+    oldtables<-lapply(sample.margins, function(margin) svytable(margin, design))
+    names(oldtables) <- lapply(sample.margins, all.vars)
     if (control$verbose)
-        print(oldtable)
+        print(oldtables)
 
     oldpoststrata<-design$postStrata
     iter<-0
@@ -1998,16 +1997,19 @@ rake<-function(design, sample.margins, population.margins,
                                  population.margins[[i]],
                                  compress=FALSE)
         }
-        newtable<-svytable(ff, design)
+        newtables<-lapply(sample.margins, function(margin) svytable(margin, design))
+        names(newtables) <- lapply(sample.margins, all.vars)
         if (control$verbose)
-            print(newtable)
+            print(newtables)
 
-        delta<-max(abs(oldtable-newtable))
+        delta<-sapply(seq_along(sample.margins), function(margin_index) {
+          max(abs(newtables[[margin_index]] - oldtables[[margin_index]]))
+        }) |> max()
         if (delta<epsilon){
             converged<-TRUE
             break
         }
-        oldtable<-newtable
+        oldtables<-newtables
         iter<-iter+1
     }
 


### PR DESCRIPTION
This PR is not intended to be merged in this repo, but is intended just to clearly indicate what changes would fix the issue described in #11. Instead of trying to compute one big n-way table (which isn't strictly needed), compute n separate one-way tables.