### PR TITLE
Adjustment for two-phase with unweighted, with-replacement first phase

### DIFF
--- a/R/twophase2.R
+++ b/R/twophase2.R
@@ -100,8 +100,11 @@ Dcheck_multi_subset<-function(id,strata,subset,probs,withreplacement){
    nstage<-NCOL(id)
    n<-sum(subset)
    rval<-matrix(0,n,n)
-   if (all(probs==1) && withreplacement)
-       return(as(diag(n),"sparseMatrix"))
+   if (all(probs==1) && withreplacement) {
+     probs <- probs - 1
+     withreplacement <- FALSE
+     nstage <- 1L
+   }
    sampsize<-NULL
    for(stage in 1:nstage){
        uid<-rep(FALSE,NROW(id))
@@ -113,7 +116,7 @@ Dcheck_multi_subset<-function(id,strata,subset,probs,withreplacement){
        rval<- twophaseDcheck(rval, this_stage)
      }
    rval
- }
+   }
 
 twophaseDcheck<-function(Dcheck1,Dcheck2){
   as(-Dcheck1*Dcheck2+Dcheck1+Dcheck2,"sparseMatrix")

--- a/tests/twophase.R
+++ b/tests/twophase.R
@@ -131,3 +131,19 @@ all.equal(Vphase2,drop(attr(vcov(tot2),"phases")$phase2))
 Vphase1/attr(vcov(tot),"phases")$phase1
 all.equal(Vphase1,as.vector(attr(vcov(tot2),"phases")$phase1))
 
+## check for special case when first phase is unweighted and with replacement
+  twophase_svy <- twophase(
+    data   = data.frame(
+      STRATUM = c(1, 1, 2, 2),
+      PSU     = c(1, 2, 3, 4),
+      PHASE_2 = c(T, F, T, T),
+      y       = c(10, 12, 9, 13)
+    ),
+    strata = list(~STRATUM, NULL),
+    id     = list(~ PSU, ~ PSU),
+    subset = ~ PHASE_2,
+    method = "full"
+  )
+
+  vcov_y <- svytotal(x = ~ y, design = twophase_svy) |> vcov() |> as.numeric()
+  all.equal(4.44, round(vcov_y, 2))


### PR DESCRIPTION
This fixes the issue identified in #10. When the first phase is unweighted and with-replacement, the quadratic form matrix for the first phase now corresponds to the usual SRSWOR variance estimator. I added a check to the test script to check for the expected variance estimate with a small example dataset.